### PR TITLE
Make adhesion URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ Le site se recharge tout seul lors d'une modification
 
 ## Configuration
 
+### URL d'adhésion
+
+L'URL d'adhésion est configurable via la variable d'environnement `ADHESION_URL`.
+
+Si elle n'est pas définie, le site utilise par défaut la campagne HelloAsso 2026 :
+
+`https://www.helloasso.com/associations/alsace-digitale/adhesions/membre-alsace-digitale-2026`
+
+Cette valeur est utilisée :
+
+- pour les liens d'adhésion affichés sur la page d'accueil ;
+- pour la redirection `GET /adhesion`.
+
 ### Redirection
 
 La redirection se configure dans le fichier `routes/redirects.json`
@@ -47,6 +60,15 @@ La redirection se configure dans le fichier `routes/redirects.json`
         "url": "http://neverssl.com/",
         "method": "redirect",
         "code": 302
+    },
+    "/adhesion": {
+        "method": "redirect",
+        "code": 302,
+        "urlEnv": "ADHESION_URL",
+        "urlConfig": "adhesionUrl"
     }
 }
 ```
+
+Le champ `urlEnv` permet de lire une URL depuis une variable d'environnement.
+Le champ `urlConfig` permet d'utiliser la valeur exposée par `config.js` comme repli si la variable n'est pas définie.

--- a/app.js
+++ b/app.js
@@ -55,6 +55,7 @@ if ('development' == app.get('env')) {
 app.get('/', routes.index);
 // redirector for Cassini
 app.get('/cassini', redirect.redirect );
+app.get('/adhesion', redirect.redirect );
 app.get('/work/:id', routes.showWork );
 app.get('/users', user.list);
 app.post('/send/msg', message.send )

--- a/config.js
+++ b/config.js
@@ -1,0 +1,11 @@
+var DEFAULT_ADHESION_URL = 'https://www.helloasso.com/associations/alsace-digitale/adhesions/membre-alsace-digitale-2026';
+
+function envOrDefault(name, fallback) {
+    return process.env[name] || fallback;
+}
+
+module.exports = {
+    DEFAULT_ADHESION_URL: DEFAULT_ADHESION_URL,
+    adhesionUrl: envOrDefault('ADHESION_URL', DEFAULT_ADHESION_URL),
+    envOrDefault: envOrDefault
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -21,9 +21,10 @@ const globals = {
 }
 
 const team = require('./team.json')
+const config = require('../config')
 
 exports.index = function(req, res){
-  res.render('index', {...globals, title: 'Alsace Digitale', team: team  });
+  res.render('index', {...globals, title: 'Alsace Digitale', team: team, adhesionUrl: config.adhesionUrl });
 };
 
 exports.showWork = function( req, res ) {

--- a/routes/redirect.js
+++ b/routes/redirect.js
@@ -1,11 +1,27 @@
 var redirects = require('./redirects.json');
+var config = require('../config');
+
+function resolveRedirectUrl(redirectConfig) {
+    if (!redirectConfig.urlEnv) {
+        return redirectConfig.url;
+    }
+
+    var fallbackUrl = redirectConfig.url;
+
+    if (redirectConfig.urlConfig && config[redirectConfig.urlConfig]) {
+        fallbackUrl = config[redirectConfig.urlConfig];
+    }
+
+    return config.envOrDefault(redirectConfig.urlEnv, fallbackUrl);
+}
 
 
 exports.redirect = function (req, res) {
     var path = req.path;
     if (redirects[path]) {
-        var redirectConfig = redirects[path];
+        var redirectConfig = Object.assign({}, redirects[path]);
         console.log("found redirect for", path);
+        redirectConfig.url = resolveRedirectUrl(redirectConfig);
         console.log(redirectConfig)
 
         // if the og:image is relative, make it absolute

--- a/routes/redirects.json
+++ b/routes/redirects.json
@@ -1,4 +1,10 @@
 {
+    "/adhesion": {
+        "method": "redirect",
+        "code": 302,
+        "urlEnv": "ADHESION_URL",
+        "urlConfig": "adhesionUrl"
+    },
     "/cassini": {
         "url": "https://alsacedigitale.wixsite.com/cassinihackathonstra",
         "method": "meta-refresh",

--- a/views/index.pug
+++ b/views/index.pug
@@ -95,7 +95,7 @@ block content
                                     li
                                         a(href='#contacts') CONTACT
                                     li
-                                        a(href='http://inscription.alsacedigitale.org/', target='_blank') ADHÉRER
+                                        a(href=adhesionUrl, target='_blank') ADHÉRER
             section#whoarewe
                 .row
                     .col-xs-12.col-sm-10.col-sm-offset-1.intro
@@ -304,7 +304,7 @@ block content
                             pour animer le tissu économique local. Nos actions sont possibles grâce à l'implication
                             de nos bénévoles.
                         p   A ce titre, nous avons toujours à coeur&nbsp;
-                            a(href="http://inscription.alsacedigitale.org" target="_blank")
+                            a(href=adhesionUrl target="_blank")
                                 | d'accueillir toutes les bonnes volontés.
 
                 .container.row


### PR DESCRIPTION
## Summary
- make the membership URL configurable via `ADHESION_URL`
- reuse the same value for homepage CTAs and the new `/adhesion` redirect
- document the new configuration and redirect behavior

## Verification
- started the app locally without `ADHESION_URL`
- verified `GET /adhesion` returns `302` to the HelloAsso 2026 URL
- started the app locally with `ADHESION_URL=https://example.org/adhesion-test`
- verified the homepage and `GET /adhesion` use the overridden URL