### PR TITLE
Add invisible redirect for /robotechgirls

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,6 +56,7 @@ app.get('/', routes.index);
 // redirector for Cassini
 app.get('/cassini', redirect.redirect );
 app.get('/adhesion', redirect.redirect );
+app.get('/robotechgirls', redirect.redirect );
 app.get('/work/:id', routes.showWork );
 app.get('/users', user.list);
 app.post('/send/msg', message.send )

--- a/routes/redirects.json
+++ b/routes/redirects.json
@@ -13,5 +13,12 @@
         "description": "Welcome to the 2025 Cassini Hackathon in Strasbourg!",
         "keywords": "Cassini, hackathon, Strasbourg, 2025",
         "image": "/images/social/cassini.jpg"
+    },
+    "/robotechgirls": {
+        "url": "https://pdf-to-web-links.lovable.app/",
+        "method": "embed",
+        "title": "Robotech Girls",
+        "description": "Robotech Girls Day",
+        "keywords": "Robotech Girls Day"
     }
 }


### PR DESCRIPTION
## Summary
- add the /robotechgirls route to the existing redirect handler
- configure an embedded redirect to https://pdf-to-web-links.lovable.app/
- keep the visitor on the local URL by rendering the target in an iframe

## Testing
- validate routes/redirects.json with node JSON.parse
- start the app on port 3456 and request /robotechgirls
- confirm the response renders an iframe targeting the Lovable URL
