### PR TITLE
Add semaineia embedded redirect

### DIFF
--- a/app.js
+++ b/app.js
@@ -57,6 +57,7 @@ app.get('/', routes.index);
 app.get('/cassini', redirect.redirect );
 app.get('/adhesion', redirect.redirect );
 app.get('/robotechgirls', redirect.redirect );
+app.get('/semaineia', redirect.redirect );
 app.get('/work/:id', routes.showWork );
 app.get('/users', user.list);
 app.post('/send/msg', message.send )

--- a/routes/redirects.json
+++ b/routes/redirects.json
@@ -20,5 +20,12 @@
         "title": "Robotech Girls",
         "description": "Robotech Girls Day",
         "keywords": "Robotech Girls Day"
+    },
+    "/semaineia": {
+        "url": "https://alsace-semaine-ia.lovable.app",
+        "method": "embed",
+        "title": "Semaine de l'IA en Alsace",
+        "description": "Semaine de l'Intelligence Artificielle en Alsace",
+        "keywords": "IA, Intelligence Artificielle, Alsace, semaine"
     }
 }


### PR DESCRIPTION
## Summary
- Adds `/semaineia` route pointing to https://alsace-semaine-ia.lovable.app
- Uses embed method (iframe) like `/robotechgirls`
- For the Semaine de l'IA en Alsace event

## Test plan
- [ ] Visit `alsacedigitale.org/semaineia` after deploy and verify the embedded page loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)