### PR TITLE
Add Robokraft redirect

### DIFF
--- a/app.js
+++ b/app.js
@@ -57,6 +57,7 @@ app.get('/', routes.index);
 app.get('/cassini', redirect.redirect );
 app.get('/adhesion', redirect.redirect );
 app.get('/robotechgirls', redirect.redirect );
+app.get('/robokraft', redirect.redirect );
 app.get('/semaineia', redirect.redirect );
 app.get('/work/:id', routes.showWork );
 app.get('/users', user.list);

--- a/routes/redirects.json
+++ b/routes/redirects.json
@@ -21,6 +21,13 @@
         "description": "Robotech Girls Day",
         "keywords": "Robotech Girls Day"
     },
+    "/robokraft": {
+        "url": "https://data-event-magnet.lovable.app",
+        "method": "embed",
+        "title": "Robokraft",
+        "description": "Événement Robokraft",
+        "keywords": "Robokraft"
+    },
     "/semaineia": {
         "url": "https://alsace-semaine-ia.lovable.app",
         "method": "embed",

--- a/routes/redirects.json
+++ b/routes/redirects.json
@@ -24,9 +24,9 @@
     "/robokraft": {
         "url": "https://data-event-magnet.lovable.app",
         "method": "embed",
-        "title": "Robokraft",
-        "description": "Événement Robokraft",
-        "keywords": "Robokraft"
+        "title": "RoboKraft 2026 — Challenge de robotique et d’IA",
+        "description": "Du 2 au 4 octobre 2026, RoboKraft réunit des équipes autour de défis de robotique, vision par ordinateur et intelligence artificielle, inspirés de l’exploration spatiale.",
+        "keywords": "RoboKraft, challenge robotique, intelligence artificielle, vision par ordinateur, bras robotique, LeRobot, LeKiwi, exploration spatiale, octobre 2026"
     },
     "/semaineia": {
         "url": "https://alsace-semaine-ia.lovable.app",


### PR DESCRIPTION
## What changed

Adds the `/robokraft` event route and configures it to embed `https://data-event-magnet.lovable.app`.

## Why

Makes the Robokraft event accessible from the Alsace Digitale website.

## Validation

- Started the Express application locally
- Confirmed `GET /robokraft` returns `200 OK`
- Confirmed the rendered iframe targets the requested URL
- Ran `git diff --check`
