### PR TITLE
Rename RobotKraft redirect

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,6 +58,7 @@ app.get('/cassini', redirect.redirect );
 app.get('/adhesion', redirect.redirect );
 app.get('/robotechgirls', redirect.redirect );
 app.get('/robokraft', redirect.redirect );
+app.get('/robotkraft', redirect.redirect );
 app.get('/semaineia', redirect.redirect );
 app.get('/work/:id', routes.showWork );
 app.get('/users', user.list);

--- a/app.js
+++ b/app.js
@@ -57,7 +57,6 @@ app.get('/', routes.index);
 app.get('/cassini', redirect.redirect );
 app.get('/adhesion', redirect.redirect );
 app.get('/robotechgirls', redirect.redirect );
-app.get('/robokraft', redirect.redirect );
 app.get('/robotkraft', redirect.redirect );
 app.get('/semaineia', redirect.redirect );
 app.get('/work/:id', routes.showWork );

--- a/routes/redirects.json
+++ b/routes/redirects.json
@@ -22,11 +22,16 @@
         "keywords": "Robotech Girls Day"
     },
     "/robokraft": {
+        "url": "/robotkraft",
+        "method": "redirect",
+        "code": 301
+    },
+    "/robotkraft": {
         "url": "https://data-event-magnet.lovable.app",
         "method": "embed",
-        "title": "RoboKraft 2026 — Challenge de robotique et d’IA",
-        "description": "Du 2 au 4 octobre 2026, RoboKraft réunit des équipes autour de défis de robotique, vision par ordinateur et intelligence artificielle, inspirés de l’exploration spatiale.",
-        "keywords": "RoboKraft, challenge robotique, intelligence artificielle, vision par ordinateur, bras robotique, LeRobot, LeKiwi, exploration spatiale, octobre 2026"
+        "title": "RobotKraft 2026 — Challenge de robotique et d’IA",
+        "description": "Du 2 au 4 octobre 2026, RobotKraft réunit des équipes autour de défis de robotique, vision par ordinateur et intelligence artificielle, inspirés de l’exploration spatiale.",
+        "keywords": "RobotKraft, challenge robotique, intelligence artificielle, vision par ordinateur, bras robotique, LeRobot, LeKiwi, exploration spatiale, octobre 2026"
     },
     "/semaineia": {
         "url": "https://alsace-semaine-ia.lovable.app",

--- a/routes/redirects.json
+++ b/routes/redirects.json
@@ -21,11 +21,6 @@
         "description": "Robotech Girls Day",
         "keywords": "Robotech Girls Day"
     },
-    "/robokraft": {
-        "url": "/robotkraft",
-        "method": "redirect",
-        "code": 301
-    },
     "/robotkraft": {
         "url": "https://data-event-magnet.lovable.app",
         "method": "embed",


### PR DESCRIPTION
## What changed

Renames the public event route to `/robotkraft` and updates the RobotKraft metadata.

## Validation

- Confirmed `GET /robotkraft` returns `200 OK` and renders the expected iframe and metadata
- Confirmed the former `/robokraft` route returns `404`
- Ran `git diff --check`